### PR TITLE
Add a new dummy annotation and force RevisionHistoryLimit to 1 when patching.

### DIFF
--- a/src/HookTrigger.Worker/KubernetesWorker.cs
+++ b/src/HookTrigger.Worker/KubernetesWorker.cs
@@ -60,9 +60,13 @@ namespace HookTrigger.Worker
 
                     await _kubernetesService.PatchAllDeploymentAsync(message?.Repository?.RepoName, message?.PushData?.Tag, stoppingToken);
                 }
+                catch (ConsumeException ex)
+                {
+                    _logger.LogError(ex, "Could not consume the specified Kafka topic.");
+                }
                 catch (Exception ex)
                 {
-                    _logger.LogCritical(ex, "An error occurred while calling K8S API.");
+                    _logger.LogCritical(ex, "An error occurred while calling K8s API.");
                 }
             }
         }

--- a/src/HookTrigger.Worker/Services/KubernetesService.cs
+++ b/src/HookTrigger.Worker/Services/KubernetesService.cs
@@ -80,6 +80,8 @@ namespace HookTrigger.Worker.Services
 
             patch.Replace(s => s.Spec.Template.Metadata.Annotations, date);
 
+            //TODO: Get the number of revision to be kept from configuration.
+            patch.Replace(s => s.Spec.RevisionHistoryLimit, 1);
             patch.Replace(s => s.Spec.Template.Spec, deployment.Spec.Template.Spec);
             patch.Replace(s => s.Spec.Template.Spec.TerminationGracePeriodSeconds, random.Next(31, 60));
 

--- a/src/HookTrigger.Worker/Services/KubernetesService.cs
+++ b/src/HookTrigger.Worker/Services/KubernetesService.cs
@@ -70,8 +70,18 @@ namespace HookTrigger.Worker.Services
             var patch = new JsonPatchDocument<V1Deployment>();
             var random = new Random();
 
+            // Add a new dummy annotation so that the deployment can be restarted even if the image is "latest"
+            // https://stackoverflow.com/questions/57559357/how-to-rolling-restart-pods-without-changing-deployment-yaml-in-kubernetes
+
+            var date = new Dictionary<string, string>
+            {
+                { "Date", DateTimeOffset.Now.ToUnixTimeSeconds().ToString() }
+            };
+
+            patch.Replace(s => s.Spec.Template.Metadata.Annotations, date);
+
             patch.Replace(s => s.Spec.Template.Spec, deployment.Spec.Template.Spec);
-            patch.Replace(s => s.Spec.Template.Spec.TerminationGracePeriodSeconds, random.Next(10, 30));
+            patch.Replace(s => s.Spec.Template.Spec.TerminationGracePeriodSeconds, random.Next(31, 60));
 
             return patch;
         }


### PR DESCRIPTION
Deployments having image "latest" are still not getting restarted, as workaround we are adding a dummy annotation to force trigger the restart.